### PR TITLE
Exception handling

### DIFF
--- a/src/giterm/exception.py
+++ b/src/giterm/exception.py
@@ -1,17 +1,17 @@
 # -*- coding: utf-8 -*-
 
 
-class ArgumentException(Exception):
+class GitermException(Exception):
     pass
 
 
-class NotAGitRepositoryException(Exception):
+class ArgumentException(GitermException):
     pass
 
 
-class GitNotFoundException(Exception):
+class NotAGitRepositoryException(GitermException):
     pass
 
 
-class CommandErrorException(Exception):
+class GitNotFoundException(GitermException):
     pass

--- a/src/giterm/giterm.py
+++ b/src/giterm/giterm.py
@@ -10,6 +10,7 @@ import six
 import giterm.watch as watch
 import giterm.rungit as run
 import giterm.cursutils as cu
+import giterm.exception as ex
 
 from giterm.gui import GitermPanelManager
 from giterm._version import __version_text__
@@ -138,7 +139,13 @@ def _main():
     # Setup ESCAPE key
     os.environ.setdefault('ESCDELAY', '5')
 
-    curses.wrapper(main, repo=args.repo)
+    try:
+        curses.wrapper(main, repo=args.repo)
+    except ex.GitermException as exc:
+        print(exc)
+        parser.print_usage()
+    except Exception as exc:
+        print(f'giterm: error: {exc}')
 
 
 if __name__ == '__main__':

--- a/src/giterm/giterm.py
+++ b/src/giterm/giterm.py
@@ -114,6 +114,9 @@ def main(stdscr, repo=None):
     # If we were given a repository directory,
     #   use it instead of our cwd.
     if repo:
+        if not os.path.isdir(repo):
+            raise ex.ArgumentException(
+                'Given repo argument is not a repository')
         os.chdir(repo)
 
     try:


### PR DESCRIPTION
Dear Tim,

Thanks for this easy-to-use Git tool!

Please find below a modest contribution. Feel free to adapt, improve, or discard it ;-)

## Problem

1. When an error occurs in Giterm, the raw exception is thrown in the terminal. Example:

```
$ giterm $HOME
Traceback (most recent call last):
  File "$HOME/g.virtualenvs/giterm-pip/bin/giterm", line 8, in <module>
    sys.exit(_main())
  File "$HOME/g.virtualenvs/giterm-pip/lib/python3.10/site-packages/giterm/giterm.py", line 141, in _main
    curses.wrapper(main, repo=args.repo)
  File "/usr/lib/python3.10/curses/__init__.py", line 94, in wrapper
    return func(stdscr, *args, **kwds)
  File "$HOME/g.virtualenvs/giterm-pip/lib/python3.10/site-packages/giterm/giterm.py", line 119, in main
    git_root_dir = run.git_root_path()
  File "$HOME/g.virtualenvs/giterm-pip/lib/python3.10/site-packages/giterm/rungit.py", line 55, in git_root_path
    raise ex.NotAGitRepositoryException(
giterm.exception.NotAGitRepositoryException: Please cd in a Git repository first.
```

2. Giving 'repo' argument to Giterm which is not a repository raises exceptions. Examples:
```
$ giterm $HOME/tmp.txt
Traceback (most recent call last):
  ....
NotADirectoryError: [Errno 20] Not a directory: 'tmp.txt'
$ giterm 1
Traceback (most recent call last):
  ....
FileNotFoundError: [Errno 2] No such file or directory: '1'
```

## Proposal

1. Catch all exceptions that may be thrown and print them. I distinguish two types of exceptions:
* `GitermException` : custom exceptions raised due to bad Giterm usage (Git missing on system, not a Git repository, etc). Those exceptions are printed in addition to the Giterm usage ;
```
$ giterm $HOME
Please cd in a Git repository first.
usage: giterm [-h] [-v] [repo]
```
* `Exception` : classic exceptions mostly dedicated to "internal error", printed with the prefix "giterm: error:".
```
giterm: error: Height and width must be at least 8x40.
```

2. When 'repo' is defined, check if it is a repository before `chdir()`. If it's not, raises a `GitermException` such as:
```
$ giterm 1
Given repo argument is not a repository
usage: giterm [-h] [-v] [repo]
```